### PR TITLE
Improve proxy setup automation and Android docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,19 @@
 # Hostname used for the TLS proxy server (add it to /etc/hosts)
 SOCKET_PROXY_HOST=socket-proxy.local
 
+# Exposed HTTPS port for the proxy (change if 443 is taken locally)
+SOCKET_PROXY_PORT=443
+
 # Socket.IO proxy used for integration tests and helper scripts
 # Replace with the HTTPS endpoint of your development proxy (see docs/testing-with-proxy.md)
 SOCKET_IO_PROXY_URL=https://socket-proxy.local
+
+# Example app proxy settings (used by Vite and mobile launcher scripts)
+# Canonical HTTPS endpoint of your proxy (must match the certificate hostname)
+# `npm run proxy:setup` writes these values for you when using the bundled Docker proxy
+VITE_SOCKET_PROXY_URL=https://socket-proxy.local
+
+# Optional: provide an alternate LAN IP for Android emulators. When set, the
+# Android launcher script updates /system/etc/hosts so the hostname above
+# resolves to this address before installing the app.
+# ANDROID_PROXY_LAN_IP=192.168.0.28

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Vite and ready for both web and native testing.
 ```bash
 cd example-app
 npm install
-npm run dev
+npm run build
 ```
 
 To launch the native demo on Android:
@@ -125,6 +125,35 @@ npx cap run android
 
 The UI includes controls to connect, emit events, and view the forwarded event log in real time. It
 defaults to `https://socket-proxy.local/` as a reminder to supply your own TLS proxy endpoint.
+
+Populate the following variables in the repository’s `.env` file to align the playground with the
+bundled Docker proxy. Running `npm run proxy:setup` writes these values for you:
+
+```env
+SOCKET_PROXY_PORT=443
+VITE_SOCKET_PROXY_URL=https://socket-proxy.local
+ANDROID_PROXY_LAN_IP=192.168.0.28
+```
+
+The Android launcher (`npm run test:android`) now adds the required hosts entry automatically when
+`ANDROID_PROXY_LAN_IP` is set. Use the commands below only if you need to perform the mapping
+manually. It reads the repository root `.env` even when run from `example-app/`, so rerun the
+launcher after network changes to refresh the device mapping:
+
+> **Custom port:** If you run the proxy on a port other than 443, append it to any URLs above—for
+> example `VITE_SOCKET_PROXY_URL=https://socket-proxy.local:4443`.
+
+```bash
+adb root
+adb remount
+adb shell "echo '192.168.0.28 socket-proxy.local' >> /system/etc/hosts"
+adb reboot
+```
+
+> **Emulator images:** Pick a *Google APIs* system image (avoid the Google Play Store flavour) when
+> creating AVDs. These images allow `/system` to be remounted read/write. The launcher boots new
+> emulators with `-writable-system`, but pre-existing emulators must be restarted with that flag for
+> the automatic host mapping to succeed.
 
 ### Testing with a TLS Socket.IO proxy
 
@@ -141,7 +170,8 @@ endpoint—bring (or stand up) your own proxy instead:
 4. Import the certificate authority into your Android emulator/iOS simulator or real devices so they
 	trust the proxy.
 5. Point the plugin, example app, and automated tests at the proxy hostname. The repository’s
-	scripts read from `.env`, so update `SOCKET_IO_PROXY_URL` accordingly.
+	scripts read from `.env`, so update `SOCKET_IO_PROXY_URL` (for helper scripts) and
+	`VITE_SOCKET_PROXY_URL` (for the example app) accordingly.
 
 See [`docs/testing-with-proxy.md`](./docs/testing-with-proxy.md) for a walkthrough that includes
 `mkcert` commands, sample proxy configuration, and extra tips for CI environments.
@@ -172,17 +202,24 @@ Breaking changes will be called out in the changelog together with migration ste
 
 ### Run the bundled proxy stack
 
-For a quick bootstrap, the repository includes a Docker Compose stack under `docker/`:
+For a quick bootstrap, the repository includes a Docker Compose stack under `docker/`. The fastest
+path is:
 
 ```bash
-# Generate certs with mkcert and place them in docker/certs/
-cp .env.example .env  # adjust SOCKET_PROXY_HOST if desired
-echo "127.0.0.1 socket-proxy.local" | sudo tee -a /etc/hosts
-npm run proxy:up
+npm run proxy:setup
 ```
 
-The stack exposes HTTPS on port 443 and self-hosts the upstream Socket.IO test server. Shut it down
-with `npm run proxy:down` and watch logs with `npm run proxy:logs`.
+The setup script checks for mkcert, generates `docker/certs/socket-proxy.pem`, normalises `.env`,
+and starts the containers detached. Ensure the Docker daemon is running beforehand. Prefer to run
+steps manually (or on a host without Docker)? Append `--no-start` to skip launching the containers,
+and start them later with `npm run proxy:up`. Need a different hostname? Add
+`--host dev.example.com`. Port 443 already taken locally? Use `--port 4443` (or another free port);
+the script updates `.env`, rewrites the proxy URL with the new port, and passes it to Docker
+Compose.
+
+The stack exposes HTTPS on the port you choose (defaults to 443) and self-hosts the upstream
+Socket.IO test server. Shut it down with `npm run proxy:down` and watch logs with
+`npm run proxy:logs`.
 
 ## Updating the generated docs
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,21 +7,32 @@ This folder contains a two-container stack that mirrors a production deployment:
 
 ## Usage
 
+> **Shortcut:** Run `npm run proxy:setup` from the repository root to execute the steps below
+> automatically. The script checks for mkcert, generates certificates, normalises `.env`, and starts
+> the stack detached (Docker must be running). Need a different hostname? Pass
+> `--host dev.example.com`. Port 443 already in use? Add `--port 4443` (or another open port). Want
+> to skip launching containers on this machine? Append `--no-start`.
+> Manual instructions remain available for fine-grained control.
+
 1. Generate a trusted certificate for `socket-proxy.local` (see `docs/testing-with-proxy.md`).
 2. Copy the certificate files into `docker/certs/` as `socket-proxy.pem` (certificate chain) and
    `socket-proxy-key.pem` (private key). The directory is ignored by git so you can safely store
    local certs here.
-3. Ensure the hostname resolves to your machine (for example add `127.0.0.1 socket-proxy.local` to
-   `/etc/hosts`).
-4. From the repository root, run:
+3. Ensure the hostname resolves to your machine by mapping it to your LAN IP (for example add
+   `192.168.0.28 socket-proxy.local` to `/etc/hosts`). Run `npm run proxy:setup --write-hosts`
+   on macOS/Linux to attempt the change automatically (you’ll be prompted for sudo if required).
+4. If port 443 is busy on your machine, set `SOCKET_PROXY_PORT` in the repository `.env` file (for
+   example `SOCKET_PROXY_PORT=4443`). From the repository root, run:
 
    ```bash
    npm run proxy:up
    ```
 
-   This builds the upstream server image, starts both containers, and exposes HTTPS on port 443.
+   This builds the upstream server image, starts both containers, and exposes HTTPS on the port you
+   configured (defaults to 443).
 
-5. Export or record `SOCKET_IO_PROXY_URL=https://socket-proxy.local` (the default in `.env.example`).
+5. Export or record `SOCKET_IO_PROXY_URL=https://socket-proxy.local` (append `:<port>` if you chose a
+   non-default port) — the script writes this automatically when you use `npm run proxy:setup`.
 6. When you are done, stop the stack with:
 
    ```bash

--- a/docker/docker-compose.proxy.yml
+++ b/docker/docker-compose.proxy.yml
@@ -21,7 +21,7 @@ services:
     environment:
       SOCKET_PROXY_HOST: ${SOCKET_PROXY_HOST:-socket-proxy.local}
     ports:
-      - "443:443"
+      - "${SOCKET_PROXY_PORT:-443}:443"
     command: >-
       /bin/sh -c "envsubst '$$SOCKET_PROXY_HOST' < /etc/nginx/templates/default.conf.template > /etc/nginx/conf.d/default.conf
       && nginx -g 'daemon off;'"

--- a/docker/socket-server/socket-server.mjs
+++ b/docker/socket-server/socket-server.mjs
@@ -10,7 +10,7 @@ const io = new Server(httpServer, {
   path,
 });
 
-aio.on('connection', (socket) => {
+io.on('connection', (socket) => {
   console.log(`[upstream] client ${socket.id} connected`);
 
   socket.on('ping', (payload, ack) => {

--- a/docs/testing-with-proxy.md
+++ b/docs/testing-with-proxy.md
@@ -21,7 +21,13 @@ Substitute your organisation’s internal CA or another PKI solution if preferre
 ## Quick start with Docker Compose
 
 Prefer a ready-made environment? This repository ships a Docker stack that launches an upstream
-Socket.IO server and an HTTPS reverse proxy. At a glance:
+Socket.IO server and an HTTPS reverse proxy. Run `npm run proxy:setup` from the repo root to
+generate certificates with mkcert, normalise `.env`, and bring the stack up automatically (ensure
+Docker is running first). Append `--host dev.example.com` to use a different hostname, `--port 4443`
+if 443 is already taken locally, or `--no-start` if you only want the certificates and `.env`
+updates without launching Docker. The script inspects active listeners and prints whichever process
+currently owns a conflicting port so you can resolve the clash quickly. Under the hood the script
+performs the following steps (you can run them manually if you prefer):
 
 1. Generate certificates for `socket-proxy.local` (steps below) and drop them into
   `docker/certs/` as `socket-proxy.pem` (certificate chain) and `socket-proxy-key.pem` (private
@@ -33,9 +39,9 @@ Socket.IO server and an HTTPS reverse proxy. At a glance:
     -key-file docker/certs/socket-proxy-key.pem \
     socket-proxy.local "*.socket-proxy.local"
   ```
-2. Add the hostname to your hosts file: `127.0.0.1 socket-proxy.local`.
-3. Copy `.env.example` to `.env` and set `SOCKET_PROXY_HOST` / `SOCKET_IO_PROXY_URL` if you prefer a
-  different hostname.
+2. Map the hostname to your machine’s LAN IP in the hosts file (for example `192.168.0.28 socket-proxy.local`). You can add it manually or let `npm run proxy:setup --write-hosts` try to update `/etc/hosts` for you (macOS/Linux; prompts for sudo if needed). On Windows, run an elevated editor and add the entry manually.
+3. Copy `.env.example` to `.env` (the setup script handles this) and set `SOCKET_PROXY_HOST` /
+  `SOCKET_IO_PROXY_URL` if you prefer a different hostname.
 4. Start the stack from the repo root:
 
   ```bash
@@ -159,13 +165,48 @@ Set the proxy URL in each place you integrate with the plugin:
 - **Plugin calls:** pass `url: 'https://socket-proxy.local'` to `CapacitorSocketIO.connect()`.
 - **Android unit tests:** set `SOCKET_IO_PROXY_URL` in `.env` (or export it manually) before running
   `npm run verify:android`.
-- **Example app:** update the Server URL field from its placeholder to your proxy hostname.
+- **Example app:** update the Server URL field from its placeholder to your proxy hostname—or set
+  `VITE_SOCKET_PROXY_URL` in `.env`. When the proxy runs on a LAN IP that differs from the hostname
+  in your certificate, also set `ANDROID_PROXY_LAN_IP` so the Android launcher script writes an entry
+  to `/system/etc/hosts` before installing the app:
+
+  ```env
+  SOCKET_PROXY_PORT=443
+  VITE_SOCKET_PROXY_URL=https://socket-proxy.local
+  ANDROID_PROXY_LAN_IP=192.168.0.28
+  ```
 - **Helper scripts:** populate `SOCKET_IO_PROXY_URL` in `.env` for `scripts/test-socket.js` /
   `test-socket.mjs`.
+
+If you pick a non-default port, append it to the URLs above—for example
+`VITE_SOCKET_PROXY_URL=https://socket-proxy.local:4443`.
+
+Per-platform overrides were previously required for emulators; the launcher script now handles host
+mapping automatically when `ANDROID_PROXY_LAN_IP` is present.
 
 > **Consistency check:** Whatever hostname your certificate covers must match `SOCKET_PROXY_HOST`
 > and `SOCKET_IO_PROXY_URL`. If you issue a new cert for a different host, update `.env` and remove
 > any stale cert/key pairs from `docker/certs/` so the Docker proxy mounts the correct files.
+
+> **Android emulators:** When your proxy runs on the host machine (for example listening on
+> `192.168.0.28`), the launcher script adds a hosts entry automatically if `ANDROID_PROXY_LAN_IP`
+> is provided. To apply the mapping manually (or on older builds):
+>
+> ```bash
+> adb root
+> adb remount
+> adb shell "echo '192.168.0.28 socket-proxy.local' >> /system/etc/hosts"
+> adb reboot
+> ```
+>
+> After the reboot, install the development certificate authority on the emulator so TLS handshakes
+> succeed. Apply an equivalent mapping on physical devices via Wi-Fi advanced settings, and ensure
+> the certificate authority is trusted system-wide.
+
+> **AVD tip:** Choose a *Google APIs* system image (avoid Google Play Store images) for test AVDs.
+> These builds allow `/system` to be remounted. The `npm run test:android` script launches emulators
+> with `-writable-system`; existing emulators must be restarted with that flag for automatic host
+> mapping.
 
 ## Production hardening tips
 

--- a/example-app/README.md
+++ b/example-app/README.md
@@ -19,9 +19,48 @@ npx cap sync ios android
 ```
 
 > **Note:** The playground defaults to `https://socket-proxy.local/`. Replace it with your own
-> HTTPS proxy hostname and record the value in the root `.env` file (see
-> `docs/testing-with-proxy.md` for setup instructions). Self-signed certificates are only trusted in
-> development builds; production builds must present a CA-issued or pinned certificate.
+> HTTPS proxy hostname by setting `VITE_SOCKET_PROXY_URL=https://socket-proxy.local` (or your
+> equivalent) in the root `.env` file. Running `npm run proxy:setup` **from the repository root**
+> will generate mkcert certificates, normalise `.env`, and start the bundled Docker proxy
+> automatically (requires Docker to be running). Use `--host dev.example.com` to target a different
+> hostname, `--port 4443` if port 443 is already in use locally, or `--no-start` to skip launching
+> containers. If you are already inside `example-app/`, run `npm run proxy:setup -- --no-start`
+> from the repository root in another terminal, or use `npm --prefix .. run proxy:setup -- --no-start`
+> to invoke the script without leaving this
+> directory. If the
+> proxy is reachable on a different LAN IP from the Android emulator, provide the address via
+> `ANDROID_PROXY_LAN_IP`. The Android launcher script will add a hosts entry before installing the
+> app so the hostname resolves correctly:
+>
+> ```env
+> SOCKET_PROXY_PORT=443
+> VITE_SOCKET_PROXY_URL=https://socket-proxy.local
+> ANDROID_PROXY_LAN_IP=192.168.0.28
+> ```
+>
+> When using a non-default port, append it to the URLs—for example
+> `VITE_SOCKET_PROXY_URL=https://socket-proxy.local:4443`.
+>
+> Self-signed certificates are only trusted in development builds; production builds must present a
+> CA-issued or pinned certificate.
+
+### Accessing a LAN proxy from the Android emulator
+
+If your proxy is bound to a private IP (such as `192.168.0.28`) behind the hostname
+`socket-proxy.local`, add a hosts entry inside the emulator so that the domain resolves to the
+LAN address. When `ANDROID_PROXY_LAN_IP` is present, `npm run test:android` performs these steps
+automatically before deploying the app. To apply the mapping manually:
+
+```bash
+adb root
+adb remount
+adb shell "echo '192.168.0.28 socket-proxy.local' >> /system/etc/hosts"
+adb reboot
+```
+
+Install the development CA (for example the `mkcert` root) on the emulator afterwards so TLS
+handshakes succeed. Similar steps apply to physical devices—consult `docs/testing-with-proxy.md`
+for full details.
 
 #### iOS
 
@@ -38,6 +77,11 @@ Launch an emulator or choose a connected device directly from the prompt:
 ```bash
 npm run test:android
 ```
+
+> **Emulator requirement:** Use a Google APIs system image (not Google Play Store) so the Android
+> SDK allows `/system/etc/hosts` to be remounted read/write. The launcher starts emulators with
+> `-writable-system` automatically; if you bring your own running emulator, reboot it with
+> `emulator -avd <name> -writable-system` before running the script.
 
 During development you can keep the Vite dev server running for quick web refreshes:
 

--- a/example-app/package-lock.json
+++ b/example-app/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@capacitor/cli": "^7.4.3",
+        "dotenv": "^16.4.5",
         "vite": "^5.4.2"
       }
     },
@@ -35,6 +36,8 @@
         "@ionic/prettier-config": "^4.0.0",
         "@ionic/swiftlint-config": "^2.0.0",
         "@types/node": "^20.14.11",
+        "dotenv": "^16.4.5",
+        "dotenv-cli": "^7.4.2",
         "eslint": "^8.57.0",
         "prettier": "^3.4.2",
         "prettier-plugin-java": "^2.6.6",
@@ -4707,6 +4710,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/eastasianwidth": {

--- a/example-app/package.json
+++ b/example-app/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@capacitor/cli": "^7.4.3",
+    "dotenv": "^16.4.5",
     "vite": "^5.4.2"
   },
   "author": "",

--- a/example-app/scripts/run-mobile.mjs
+++ b/example-app/scripts/run-mobile.mjs
@@ -1,8 +1,30 @@
 #!/usr/bin/env node
+import { config as loadEnv } from 'dotenv';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { spawn, spawnSync } from 'child_process';
 import { createInterface } from 'readline/promises';
 import { stdin as input, stdout as output } from 'node:process';
 import { setTimeout as delay } from 'node:timers/promises';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Load environment variables from the example app directory and repository root without overriding existing values.
+const ENV_LOCATIONS = [
+  path.resolve(__dirname, '..', '.env.local'),
+  path.resolve(__dirname, '..', '.env'),
+  path.resolve(__dirname, '..', '..', '.env.local'),
+  path.resolve(__dirname, '..', '..', '.env'),
+];
+
+for (const candidate of ENV_LOCATIONS) {
+  const result = loadEnv({ path: candidate, override: false });
+  if (result.error && result.error.code !== 'ENOENT') {
+    console.warn(`Unable to read environment file at ${candidate}:`, result.error.message ?? result.error);
+  }
+}
+
+const { proxyHost, proxyLanIp } = resolveProxyConfig();
 
 const platform = process.argv[2];
 if (!['android', 'ios'].includes(platform)) {
@@ -38,7 +60,7 @@ async function runAndroid() {
   for (const device of deviceList) {
     options.push({
       label: `Use connected device: ${device.id} (${device.description})`,
-      run: () => runCapacitor(['cap', 'run', 'android', '--target', device.id]),
+      run: () => configureAndRunAndroid(device.id),
     });
   }
 
@@ -84,15 +106,17 @@ function listAndroidDevices() {
 }
 
 async function launchAvdAndRun(avdName, existingIds) {
-  console.log(`\nStarting emulator ${avdName}…`);
-  const emulatorProc = spawn('emulator', ['-avd', avdName], {
+  console.log(`\nStarting emulator ${avdName} with writable system image…`);
+  const emulatorProc = spawn('emulator', ['-avd', avdName, '-writable-system'], {
     stdio: 'ignore',
     detached: true,
   });
   emulatorProc.unref();
 
   const targetId = await waitForAndroidDevice(existingIds);
-  console.log(`Detected emulator ${targetId}. Installing app…\n`);
+  console.log(`Detected emulator ${targetId}. Configuring proxy mapping…`);
+  await configureAndroidHosts(targetId);
+  console.log('Installing app…\n');
   await runCapacitor(['cap', 'run', 'android', '--target', targetId]);
 }
 
@@ -199,4 +223,83 @@ function runCapacitor(args) {
       }
     });
   });
+}
+
+async function configureAndRunAndroid(targetId) {
+  await configureAndroidHosts(targetId);
+  await runCapacitor(['cap', 'run', 'android', '--target', targetId]);
+}
+
+async function configureAndroidHosts(targetId) {
+  if (!proxyHost || !proxyLanIp || proxyHost === proxyLanIp) {
+    return;
+  }
+
+  console.log(`  → Ensuring ${proxyHost} resolves to ${proxyLanIp} on device ${targetId ?? '<default>'}`);
+
+  const adbArgs = (...args) => (targetId ? ['-s', targetId, ...args] : args);
+
+  const runAdb = (args) => {
+    const result = spawnSync('adb', adbArgs(...args), { encoding: 'utf8' });
+    if (result.error) {
+      throw result.error;
+    }
+    if (result.status !== 0) {
+      const stderr = result.stderr?.trim();
+      throw new Error(`adb ${args.join(' ')} failed${stderr ? `: ${stderr}` : ''}`);
+    }
+    return result.stdout;
+  };
+
+  try {
+    runAdb(['root']);
+    await delay(750);
+    try {
+      runAdb(['remount']);
+    } catch (error) {
+      throw new Error(
+        `adb remount failed. Ensure the emulator was started with -writable-system and uses a Google APIs system image (not Google Play Store). Original error: ${
+          error?.message ?? error
+        }`,
+      );
+    }
+    const entry = `${proxyLanIp} ${proxyHost}`;
+    runAdb(['shell', `grep -q '${entry}' /system/etc/hosts || echo '${entry}' >> /system/etc/hosts`]);
+    console.log('  ✔ Host mapping applied');
+  } catch (error) {
+    console.warn('  ⚠️  Unable to update /system/etc/hosts automatically. Proceeding anyway.', error?.message ?? error);
+  }
+}
+
+function resolveProxyConfig() {
+  const canonicalUrl = process.env.VITE_SOCKET_PROXY_URL;
+  const androidUrlOverride = process.env.VITE_SOCKET_PROXY_URL_ANDROID;
+  const lanIpOverride =
+    process.env.ANDROID_PROXY_LAN_IP || process.env.VITE_SOCKET_PROXY_URL_ANDROID_LAN_IP || undefined;
+
+  const host = safeHostname(canonicalUrl) || safeHostname(androidUrlOverride);
+  const lanIp = lanIpOverride || extractLanIp(androidUrlOverride);
+
+  return { proxyHost: host, proxyLanIp: lanIp };
+}
+
+function safeHostname(url) {
+  if (!url) {
+    return undefined;
+  }
+
+  try {
+    return new URL(url).hostname;
+  } catch (error) {
+    return undefined;
+  }
+}
+
+function extractLanIp(url) {
+  const host = safeHostname(url);
+  if (!host) {
+    return undefined;
+  }
+
+  return /^(\d{1,3}\.){3}\d{1,3}$/.test(host) ? host : undefined;
 }

--- a/example-app/src/index.html
+++ b/example-app/src/index.html
@@ -143,7 +143,7 @@
         <h2>Connection</h2>
         <label class="field">
           <span>Server URL</span>
-          <input type="text" id="serverUrl" value="https://socket-proxy.local/" />
+          <input type="text" id="serverUrl" placeholder="https://socket-proxy.local/" />
         </label>
         <div class="actions">
           <button id="connectBtn">Connect</button>
@@ -177,6 +177,37 @@
       </section>
     </main>
 
+    <script type="module">
+      const FALLBACK_PROXY_URL = 'https://socket-proxy.local/';
+
+      const ensureTrailingSlash = (value) => {
+        if (!value) {
+          return FALLBACK_PROXY_URL;
+        }
+
+        return value.endsWith('/') ? value : `${value}/`;
+      };
+
+      const env = import.meta.env ?? {};
+      const sanitize = (value) => (typeof value === 'string' ? value.trim() : '');
+
+      const configuredDefaults = {
+        default: sanitize(env.VITE_SOCKET_PROXY_URL),
+        android: sanitize(env.VITE_SOCKET_PROXY_URL_ANDROID),
+        ios: sanitize(env.VITE_SOCKET_PROXY_URL_IOS),
+        web: sanitize(env.VITE_SOCKET_PROXY_URL_WEB),
+      };
+
+      const resolvedDefault = ensureTrailingSlash(configuredDefaults.default || FALLBACK_PROXY_URL);
+      const socketProxyOrigins = Object.fromEntries(
+        Object.entries(configuredDefaults).map(([platform, url]) => [platform, ensureTrailingSlash(url || resolvedDefault)]),
+      );
+
+      window.APP_CONFIG = {
+        socketProxyOrigins,
+        fallbackProxyUrl: resolvedDefault,
+      };
+    </script>
     <script src="./js/example.js" type="module"></script>
   </body>
 </html>

--- a/example-app/src/js/example.js
+++ b/example-app/src/js/example.js
@@ -1,3 +1,4 @@
+import { Capacitor } from '@capacitor/core';
 import { CapacitorSocketIO } from '@zenzig/capacitor-socket-io';
 
 const CORE_EVENTS = Object.freeze([
@@ -24,6 +25,61 @@ const disconnectBtn = document.getElementById('disconnectBtn');
 const emitBtn = document.getElementById('emitBtn');
 const clearLogBtn = document.getElementById('clearLogBtn');
 const logElement = document.getElementById('eventLog');
+
+const appConfig = (typeof window !== 'undefined' && window.APP_CONFIG) || {};
+const FALLBACK_PROXY_URL = 'https://socket-proxy.local/';
+
+const ensureTrailingSlash = (value) => {
+    if (!value) {
+        return FALLBACK_PROXY_URL;
+    }
+
+    return value.endsWith('/') ? value : `${value}/`;
+};
+
+const isIpAddress = (value) => {
+    if (typeof value !== 'string') {
+        return false;
+    }
+
+    const trimmed = value.replace(/\/+$/, '').trim();
+    return /^(\d{1,3}\.){3}\d{1,3}$/.test(trimmed);
+};
+
+const getPlatformKey = () => {
+    try {
+        const platform = typeof Capacitor?.getPlatform === 'function' ? Capacitor.getPlatform() : undefined;
+        if (typeof platform === 'string' && platform.length > 0) {
+            return platform.toLowerCase();
+        }
+    } catch (error) {
+        console.warn('Unable to determine Capacitor platform', error);
+    }
+
+    return 'web';
+};
+
+const selectProxyOrigin = () => {
+    const origins = appConfig.socketProxyOrigins || {};
+    const platformKey = getPlatformKey();
+    const fallback = typeof appConfig.fallbackProxyUrl === 'string' ? appConfig.fallbackProxyUrl : FALLBACK_PROXY_URL;
+    const canonical = origins.default || fallback;
+    const candidate = origins[platformKey];
+
+    if (candidate && platformKey === 'android' && isIpAddress(candidate) && !isIpAddress(canonical)) {
+        return ensureTrailingSlash(canonical);
+    }
+
+    const selected = candidate || canonical || fallback;
+    return ensureTrailingSlash(selected);
+};
+
+const DEFAULT_SERVER_URL = selectProxyOrigin();
+
+if (serverUrlInput) {
+    const existingValue = (serverUrlInput.value || '').trim();
+    serverUrlInput.value = ensureTrailingSlash(existingValue || DEFAULT_SERVER_URL);
+}
 
 const registeredEvents = new Set();
 const listenerHandles = new Map();

--- a/example-app/vite.config.ts
+++ b/example-app/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+  envDir: '..',
   root: './src',
   build: {
     outDir: '../dist',

--- a/package.json
+++ b/package.json
@@ -45,11 +45,12 @@
     "build": "npm run clean && npm run docgen && tsc && rollup -c rollup.config.mjs",
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
-    "proxy:up": "docker compose -f docker/docker-compose.proxy.yml up --build",
-    "proxy:down": "docker compose -f docker/docker-compose.proxy.yml down",
-  "proxy:logs": "docker compose -f docker/docker-compose.proxy.yml logs -f proxy",
-  "proxy:up:ci": "docker compose -f docker/docker-compose.proxy.yml up --build -d",
-  "proxy:down:ci": "docker compose -f docker/docker-compose.proxy.yml down --volumes --remove-orphans",
+  "proxy:up": "dotenv -e .env -- docker compose -f docker/docker-compose.proxy.yml up --build",
+  "proxy:down": "dotenv -e .env -- docker compose -f docker/docker-compose.proxy.yml down",
+  "proxy:logs": "dotenv -e .env -- docker compose -f docker/docker-compose.proxy.yml logs -f proxy",
+  "proxy:up:ci": "dotenv -e .env -- docker compose -f docker/docker-compose.proxy.yml up --build -d",
+  "proxy:down:ci": "dotenv -e .env -- docker compose -f docker/docker-compose.proxy.yml down --volumes --remove-orphans",
+    "proxy:setup": "node ./scripts/setup-proxy.mjs",
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {

--- a/scripts/setup-proxy.mjs
+++ b/scripts/setup-proxy.mjs
@@ -1,0 +1,520 @@
+#!/usr/bin/env node
+import { spawnSync } from 'child_process';
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { config as loadEnv } from 'dotenv';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '..');
+const envExamplePath = path.join(repoRoot, '.env.example');
+const envPath = path.join(repoRoot, '.env');
+const certDir = path.join(repoRoot, 'docker', 'certs');
+const certPath = path.join(certDir, 'socket-proxy.pem');
+const keyPath = path.join(certDir, 'socket-proxy-key.pem');
+const rawArgs = process.argv.slice(2);
+const options = parseArgs(rawArgs);
+const { force, noStart, host: hostOverride, port: portOverride, writeHosts } = options;
+
+function logStep(message) {
+  console.log(`\n▶ ${message}`);
+}
+
+function parseArgs(args) {
+  const result = { force: false, noStart: false, host: undefined, port: undefined, writeHosts: false };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === '--force') {
+      result.force = true;
+      continue;
+    }
+
+    if (arg === '--no-start') {
+      result.noStart = true;
+      continue;
+    }
+
+    if (arg === '--write-hosts') {
+      result.writeHosts = true;
+      continue;
+    }
+
+    if (arg.startsWith('--host=')) {
+      const value = arg.slice('--host='.length).trim();
+      if (value) {
+        result.host = value;
+      } else {
+        console.warn('Ignoring empty --host value.');
+      }
+      continue;
+    }
+
+    if (arg === '--host') {
+      const next = args[index + 1];
+      if (next && !next.startsWith('--')) {
+        result.host = next.trim();
+        index += 1;
+      } else {
+        console.warn('Ignoring --host flag without a value.');
+      }
+      continue;
+    }
+
+    if (arg.startsWith('--port=')) {
+      const value = arg.slice('--port='.length).trim();
+      if (value) {
+        result.port = value;
+      } else {
+        console.warn('Ignoring empty --port value.');
+      }
+      continue;
+    }
+
+    if (arg === '--port') {
+      const next = args[index + 1];
+      if (next && !next.startsWith('--')) {
+        result.port = next.trim();
+        index += 1;
+      } else {
+        console.warn('Ignoring --port flag without a value.');
+      }
+      continue;
+    }
+
+    console.warn(`Unknown option "${arg}" ignored.`);
+  }
+
+  return result;
+}
+
+function normalisePort(value) {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const portNumber = Number.parseInt(String(value), 10);
+  if (!Number.isFinite(portNumber) || portNumber <= 0 || portNumber > 65535) {
+    throw new Error(`Invalid port "${value}". Choose an integer between 1 and 65535.`);
+  }
+
+  return portNumber;
+}
+
+function checkPortAvailability(port) {
+  if (port === undefined) {
+    return;
+  }
+
+  if (process.platform !== 'win32') {
+    const args = ['-nP', '-iTCP', `:${port}`, '-sTCP:LISTEN'];
+    const result = spawnSync('lsof', args, { stdio: 'pipe' });
+
+    if (result.error && result.error.code === 'ENOENT') {
+      console.warn('lsof not found; skipping port availability check.');
+    } else if (result.status === 0) {
+      const listeners = parseLsofListeners(result.stdout?.toString() ?? '');
+      if (listeners.length > 0) {
+        const formatted = listeners.map((entry) => `  • ${entry}`).join('\n');
+        throw new Error(`Port ${port} appears to be in use by:\n${formatted}\n\nClose the process or rerun with --port <alternate>.`);
+      }
+    } else if (result.status === 1) {
+      // No listeners found; lsof returns exit code 1 in this case.
+    } else if (result.stderr) {
+      console.warn(`lsof reported an unexpected error while checking port ${port}: ${result.stderr.toString().trim()}`);
+    }
+  }
+
+  if (port < 1024 && typeof process.getuid === 'function' && process.getuid() !== 0) {
+    console.warn(`Port ${port} is privileged. Docker will require elevated permissions on some systems; consider choosing a port >=1024 via --port.`);
+  }
+}
+
+function parseLsofListeners(output) {
+  const lines = output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  if (lines.length <= 1) {
+    return [];
+  }
+
+  const summaries = [];
+
+  for (let index = 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    const tokens = line.split(/\s+/);
+    if (tokens.length < 9) {
+      summaries.push(line);
+      continue;
+    }
+
+    const [command, pid, user, fd, type, device, sizeOff, node, name, ...rest] = tokens;
+    const address = [name, ...rest].join(' ').replace('(LISTEN)', '').trim();
+    const descriptor = `${command} (pid ${pid}, user ${user}) listening on ${address || name}`;
+    summaries.push(descriptor);
+  }
+
+  return summaries;
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    stdio: options.stdio ?? 'inherit',
+    cwd: options.cwd ?? repoRoot,
+    env: options.env ?? process.env,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    const joined = [command, ...args].join(' ');
+    throw new Error(`${joined} exited with code ${result.status}`);
+  }
+
+  return result;
+}
+
+function ensureEnvFile() {
+  if (!existsSync(envPath)) {
+    if (!existsSync(envExamplePath)) {
+      throw new Error('Missing .env.example – cannot bootstrap .env');
+    }
+
+    copyFileSync(envExamplePath, envPath);
+    console.log('Created .env from .env.example');
+  }
+}
+
+function upsertEnvValue(key, value) {
+  const original = existsSync(envPath) ? readFileSync(envPath, 'utf8') : '';
+  const lines = original.split(/\r?\n/);
+  const keyPattern = new RegExp(`^${key}=`);
+  let updated = false;
+
+  const next = lines.map((line) => {
+    if (keyPattern.test(line)) {
+      updated = true;
+      return `${key}=${value}`;
+    }
+    return line;
+  });
+
+  if (!updated) {
+    next.push(`${key}=${value}`);
+  }
+
+  const normalised = next.filter((line, index, arr) => !(index === arr.length - 1 && line.trim() === '' && arr[index - 1]?.trim() === '')).join('\n');
+  writeFileSync(envPath, normalised.endsWith('\n') ? normalised : `${normalised}\n`, 'utf8');
+}
+
+function isIpAddress(value) {
+  if (!value) {
+    return false;
+  }
+
+  return /^\d{1,3}(?:\.\d{1,3}){3}$/.test(value);
+}
+
+function detectLanIp() {
+  const interfaces = os.networkInterfaces?.();
+  if (!interfaces) {
+    return undefined;
+  }
+
+  const candidates = [];
+  for (const value of Object.values(interfaces)) {
+    if (!Array.isArray(value)) {
+      continue;
+    }
+
+    for (const details of value) {
+      if (details && details.family === 'IPv4' && details.address && !details.internal) {
+        candidates.push(details.address);
+      }
+    }
+  }
+
+  if (candidates.length === 0) {
+    return undefined;
+  }
+
+  const sortScore = (address) => {
+    if (/^192\.168\./.test(address)) {
+      return 3;
+    }
+    if (/^10\./.test(address)) {
+      return 2;
+    }
+    if (/^172\.(1[6-9]|2\d|3[0-1])\./.test(address)) {
+      return 1;
+    }
+    return 0;
+  };
+
+  candidates.sort((a, b) => sortScore(b) - sortScore(a));
+  return candidates[0];
+}
+
+function resolveHostsFile() {
+  if (process.platform === 'win32') {
+    const systemRoot = process.env.SystemRoot || 'C:/Windows';
+    return path.join(systemRoot, 'System32', 'drivers', 'etc', 'hosts');
+  }
+  return '/etc/hosts';
+}
+
+function checkHostsEntry(host, { writeHosts = false } = {}) {
+  const hostsFile = resolveHostsFile();
+
+  try {
+    if (!existsSync(hostsFile)) {
+      console.warn(`Unable to locate hosts file at ${hostsFile}. Please add an entry mapping ${host} manually.`);
+      return;
+    }
+
+    const content = readFileSync(hostsFile, 'utf8');
+    const hasEntry = content
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .some((line) => line && !line.startsWith('#') && line.split(/\s+/).includes(host));
+
+    if (hasEntry) {
+      console.log(`Hosts entry for ${host} already present.`);
+    } else {
+      const envLanIp = process.env.ANDROID_PROXY_LAN_IP?.trim();
+      const detectedLanIp = detectLanIp();
+      const suggestedIp = envLanIp || detectedLanIp || '127.0.0.1';
+      const lanMessage = suggestedIp === '127.0.0.1'
+        ? 'Replace 127.0.0.1 with your machine’s LAN IP so Android and iOS devices can resolve it.'
+        : 'Update the IP if your LAN differs.';
+
+      if (writeHosts && suggestedIp !== '127.0.0.1') {
+        if (process.platform === 'win32') {
+          console.warn(`Automatic hosts editing is not supported on Windows. Run an elevated editor and add '${suggestedIp} ${host}' manually.`);
+        } else {
+          const applied = ensureHostsEntryWritten({ host, ip: suggestedIp, hostsFile });
+          if (applied) {
+            console.log(`Added hosts entry '${suggestedIp} ${host}'.`);
+          } else {
+            console.warn(`Unable to update ${hostsFile} automatically. Please add '${suggestedIp} ${host}' manually.`);
+          }
+        }
+      }
+
+      if (!writeHosts || suggestedIp === '127.0.0.1') {
+        console.warn(`Map ${host} in ${hostsFile} to your machine's LAN IP. Suggested entry: '${suggestedIp} ${host}'. ${lanMessage}`);
+      }
+    }
+  } catch (error) {
+    console.warn(`Unable to read ${hostsFile}: ${error.message}`);
+  }
+}
+
+function ensureHostsEntryWritten({ host, ip, hostsFile }) {
+  try {
+    const content = readFileSync(hostsFile, 'utf8');
+    const lines = content.split(/\r?\n/);
+    const filtered = lines.filter((line) => {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) {
+        return true;
+      }
+      return !trimmed.split(/\s+/).includes(host);
+    });
+
+    const nextLines = filtered.filter((line, index, arr) => !(index === arr.length - 1 && line.trim() === ''));
+    nextLines.push(`${ip} ${host}`);
+    let updated = nextLines.join('\n');
+    if (!updated.endsWith('\n')) {
+      updated += '\n';
+    }
+
+    if (typeof process.getuid === 'function' && process.getuid() === 0) {
+      writeFileSync(hostsFile, updated, 'utf8');
+      return true;
+    }
+
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), 'socket-proxy-hosts-'));
+    const tempFile = path.join(tempDir, 'hosts');
+    writeFileSync(tempFile, updated, 'utf8');
+
+    const result = spawnSync('sudo', ['cp', tempFile, hostsFile], { stdio: 'inherit' });
+    if (result.error) {
+      console.warn(`sudo cp failed: ${result.error.message}`);
+    }
+    const success = !result.error && result.status === 0;
+
+    try {
+      unlinkSync(tempFile);
+    } catch (error) {
+      if (error?.code !== 'ENOENT') {
+        console.warn(`Unable to delete temp hosts file: ${error.message}`);
+      }
+    }
+
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch (error) {
+      if (error?.code !== 'ENOENT') {
+        console.warn(`Unable to remove temp directory: ${error.message}`);
+      }
+    }
+
+    return success;
+  } catch (error) {
+    console.warn(`Failed to update hosts file automatically: ${error.message}`);
+    return false;
+  }
+}
+
+function ensureMkcert() {
+  const result = spawnSync('mkcert', ['-help'], { stdio: 'ignore' });
+  if (result.error || result.status !== 0) {
+    throw new Error('mkcert is required. Install it via "brew install mkcert" (macOS) or see https://github.com/FiloSottile/mkcert for instructions.');
+  }
+}
+
+function ensureCerts(host, { force }) {
+  mkdirSync(certDir, { recursive: true });
+
+  if (!force && existsSync(certPath) && existsSync(keyPath)) {
+    console.log('Certificate already exists. Use --force to regenerate.');
+    return;
+  }
+
+  if (force) {
+    console.log('--force supplied, regenerating certificate.');
+  }
+
+  logStep(`Installing mkcert root CA (may prompt for password)`);
+  run('mkcert', ['-install']);
+
+  logStep(`Generating development certificate for ${host}`);
+  run('mkcert', ['-cert-file', certPath, '-key-file', keyPath, host, `*.${host}`]);
+}
+
+function assertDockerDaemon() {
+  const result = spawnSync('docker', ['info'], { stdio: 'pipe' });
+
+  if (result.error) {
+    throw new Error('Docker CLI not found. Install Docker Desktop (macOS/Windows) or ensure the "docker" binary is available.');
+  }
+
+  if (result.status !== 0) {
+    const fragments = [];
+    if (result.stderr) {
+      const text = result.stderr.toString().trim();
+      if (text) {
+        fragments.push(text);
+      }
+    }
+    if (result.stdout) {
+      const text = result.stdout.toString().trim();
+      if (text) {
+        fragments.push(text);
+      }
+    }
+
+    const details = fragments.join('\n');
+    const hint = 'Docker daemon is not reachable. Start Docker Desktop or your container runtime, then rerun this script.';
+    throw new Error(details ? `${hint}\n\nDetails: ${details}` : hint);
+  }
+}
+
+function startProxyStack({ port }) {
+  logStep(`Starting Docker proxy stack (detached on port ${port})`);
+  run('npm', ['run', 'proxy:up:ci'], {
+    env: {
+      ...process.env,
+      SOCKET_PROXY_PORT: String(port),
+    },
+  });
+}
+
+function main() {
+  logStep('Preparing environment');
+  ensureEnvFile();
+  loadEnv({ path: envPath });
+
+  const envHost = process.env.SOCKET_PROXY_HOST?.trim();
+  let host = envHost && envHost.length > 0 ? envHost : 'socket-proxy.local';
+
+  if (hostOverride && hostOverride.length > 0) {
+    host = hostOverride;
+    console.log(`Using host override: ${hostOverride}`);
+  }
+
+  host = host.trim() || 'socket-proxy.local';
+
+  const defaultPort = 443;
+  let port = normalisePort(portOverride ?? process.env.SOCKET_PROXY_PORT?.trim());
+  if (port === undefined) {
+    port = defaultPort;
+  }
+
+  const proxyUrl = `https://${host}${port === 443 ? '' : `:${port}`}`;
+
+  logStep(`Normalising .env for host ${host}`);
+  upsertEnvValue('SOCKET_PROXY_HOST', host);
+  upsertEnvValue('SOCKET_PROXY_PORT', String(port));
+  upsertEnvValue('SOCKET_IO_PROXY_URL', proxyUrl);
+  upsertEnvValue('VITE_SOCKET_PROXY_URL', proxyUrl);
+
+  process.env.SOCKET_PROXY_HOST = host;
+  process.env.SOCKET_PROXY_PORT = String(port);
+  process.env.SOCKET_IO_PROXY_URL = proxyUrl;
+  process.env.VITE_SOCKET_PROXY_URL = proxyUrl;
+
+  const existingLanIp = process.env.ANDROID_PROXY_LAN_IP?.trim();
+  const detectedLanIp = !isIpAddress(host) ? detectLanIp() : undefined;
+
+  if (detectedLanIp) {
+    if (existingLanIp !== detectedLanIp) {
+      upsertEnvValue('ANDROID_PROXY_LAN_IP', detectedLanIp);
+      console.log(`Detected LAN IP ${detectedLanIp} and recorded it in .env (ANDROID_PROXY_LAN_IP).`);
+    }
+    process.env.ANDROID_PROXY_LAN_IP = detectedLanIp;
+  } else if (!existingLanIp && !isIpAddress(host)) {
+    console.warn('Unable to detect a LAN IP automatically. Set ANDROID_PROXY_LAN_IP in .env if your emulator needs a host mapping.');
+  }
+
+  ensureMkcert();
+  ensureCerts(host, { force });
+
+  logStep('Checking hosts file');
+  checkHostsEntry(host, { writeHosts });
+
+  if (!noStart) {
+    logStep(`Checking port availability for ${port}`);
+    checkPortAvailability(port);
+    logStep('Verifying Docker daemon');
+    assertDockerDaemon();
+    startProxyStack({ port });
+    console.log(`\n✅ Proxy ready at ${proxyUrl}`);
+  } else {
+    console.log(`\n⚠️  Skipping Docker startup (--no-start). Run "npm run proxy:up" when you're ready to launch the stack (target port ${port}).`);
+  }
+
+  console.log('\nNext steps:');
+  if (noStart) {
+    console.log('  • Start the proxy manually with "npm run proxy:up" (or rerun without --no-start).');
+    console.log('  • After it is running, use "npm run proxy:logs" to monitor Nginx.');
+  } else {
+    console.log('  • Run "npm run proxy:logs" in another terminal to monitor Nginx.');
+  }
+  console.log('  • Ensure your Android emulator/iOS simulator trusts the mkcert root CA.');
+  console.log('  • From example-app/, run "npm install" (first time) then "npm run test:android" or "npm run test:ios".');
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`\n❌ Setup failed: ${error.message}`);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary
- add a turnkey `scripts/setup-proxy.mjs` helper that provisions certificates, updates `.env`, writes hosts entries, and optionally starts the Docker proxy stack
- update the Android launcher so it loads the root `.env`, reapplies `/system/etc/hosts`, and documents the workflow across the README and proxy guides
- refresh the example app assets/config (UI copy, Vite config, package metadata) to default to the proxy host and surface the new automation

## Testing
- npm run proxy:setup -- --write-hosts
- npm run test:android
- curl -k -I https://socket-proxy.local